### PR TITLE
useGetUser status undefined resolved

### DIFF
--- a/src/hooks/useGetUser.js
+++ b/src/hooks/useGetUser.js
@@ -29,9 +29,13 @@ const useGetUser = (options) => {
       localStorage.removeItem('authCF');
     },
     retry: (failureCount, error) => {
-      console.log('failureCount', failureCount);
-      console.log('error', error);
-      return failureCount < 2 && error.response.status === 401;
+      if (failureCount < 2 && error?.response?.status === 401) {
+        return true;
+      } else if (failureCount < 3 && error?.response?.status !== 401) {
+        return true;
+      } else {
+        return false;
+      }
     },
     retryDelay: 1000,
     staleTime: 60 * 60 * 1000,


### PR DESCRIPTION
For reponse.status is undefined, used el Optional.chaining operator ('?.)' in error in retry function; in useGetUser useQuery options.